### PR TITLE
Cache node modules in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
 node_js:
   - "stable"
+
+# Since we're caching node_modules we have to clean up stale packages
+before_install:
+  - npm prune
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
Let's speed up "npm install" in TravisCI by caching node modules.
