### PR TITLE
Command list, fixes for caret and clicking names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roleterminal",
-  "version": "4.11.24",
+  "version": "4.11.25",
   "description": "RoleTerminal is part of an initiative to create a platform to be used in-game during LARPs",
   "author": "Aleksandar Jankovic <aleksonline@icloud.com>",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roleterminal",
-  "version": "4.11.23",
+  "version": "4.11.24",
   "description": "RoleTerminal is part of an initiative to create a platform to be used in-game during LARPs",
   "author": "Aleksandar Jankovic <aleksonline@icloud.com>",
   "private": true,

--- a/private/scripts/cmdsLocal.js
+++ b/private/scripts/cmdsLocal.js
@@ -126,49 +126,17 @@ commands.radio = {
 
 commands.help = {
   func: (phrases) => {
-    /**
-     * Returns names of all available commands for the user, based on the users access level and the commands visibility
-     * @private
-     * @returns {string[]} - Names of all available commands for the user
-     */
-    function getCommands() {
-      const allCommands = [];
-      // TODO Change from Object.keys for compatibility with older Android
-      const keys = commandHandler.getCommands();
-
-      for (let i = 0; i < keys.length; i++) {
-        const commandName = keys[i];
-        const commandAccessLevel = commandHandler.getCommandAccessLevel(commandName);
-        const commandVisibility = commandHandler.getCommandVisibility(commandName);
-
-        if (storage.getAccessLevel() >= commandAccessLevel && storage.getAccessLevel() >= commandVisibility) {
-          allCommands.push(commandName);
-        }
-      }
-
-      return allCommands.concat(Object.keys(storage.getAliases())).sort();
-    }
-
-    /**
-     * Sends all available commands as a message to the user
-     * @private
-     */
-    function getAll() {
-      const allCommands = getCommands();
+    if (undefined === phrases || phrases.length === 0) {
+      messenger.queueMessage({ text: textTools.createCommandStart('help').concat(labels.getText('instructions', 'helpExtra')) });
 
       if (storage.getUser() === null) {
         messenger.queueMessage({ text: labels.getText('info', 'useRegister') });
       }
 
       messenger.queueMessage({
-        text: allCommands,
+        text: commandHandler.getCommands(true),
         linkable: true,
       });
-    }
-
-    if (undefined === phrases || phrases.length === 0) {
-      messenger.queueMessage({ text: textTools.createCommandStart('help').concat(labels.getText('instructions', 'helpExtra')) });
-      getAll();
     } else if (phrases.length >= 1) {
       messenger.printHelpMessage(phrases[0]);
     }

--- a/private/scripts/commandHandler.js
+++ b/private/scripts/commandHandler.js
@@ -151,10 +151,36 @@ function isCommandChar(char) {
 
 /**
  * Get the names of all commands
+ * @param {Object} params - Parameters
+ * @param {boolean} params.aliases - Should aliases be included with the returned commands?
+ * @param {boolean} params.filtered - Should returned commands be filtered based on user's access level?
  * @returns {string[]} - Names of all commands
  */
-function getCommands() {
-  return Object.keys(commands);
+function getCommands(params) {
+  const keys = Object.keys(commands);
+  let allCommands;
+
+  if (params.filtered) {
+    allCommands = [];
+
+    for (let i = 0; i < keys.length; i++) {
+      const commandName = keys[i];
+      const commandAccessLevel = getCommandAccessLevel(commandName);
+      const commandVisibility = getCommandVisibility(commandName);
+
+      if (storage.getAccessLevel() >= commandAccessLevel && storage.getAccessLevel() >= commandVisibility) {
+        allCommands.push(commandName);
+      }
+    }
+  } else {
+    allCommands = keys;
+  }
+
+  if (params.aliases) {
+    allCommands = allCommands.concat(Object.keys(storage.getAliases()));
+  }
+
+  return allCommands.sort();
 }
 
 /**
@@ -212,7 +238,7 @@ function updateCommand(command) {
  * Triggered by commandHandler
  */
 function addSpecialHelpOptions() {
-  for (const command of getCommands()) {
+  for (const command of getCommands({ aliases: false })) {
     commands.help.options[command] = { description: command };
   }
 }

--- a/private/scripts/domManipulator.js
+++ b/private/scripts/domManipulator.js
@@ -126,6 +126,7 @@ function resizeInput() {
  */
 function setCommandInput(text) {
   cmdInput.value = text;
+  cmdInput.setSelectionRange(cmdInput.value.length, cmdInput.value.length);
   updateThisCommandItem();
 }
 

--- a/private/scripts/feed.js
+++ b/private/scripts/feed.js
@@ -459,7 +459,7 @@ function autoCompleteOption(phrases = [], options = {}) {
 function autoCompleteCommand() {
   const phrases = textTools.trimSpace(domManipulator.getInputText().toLowerCase()).split(' ');
   // TODO Change from Object.keys for compatibility with older Android
-  const allCommands = commandHandler.getCommands().concat(Object.keys(storage.getAliases()));
+  const allCommands = commandHandler.getCommands({ aliases: true, filtered: true });
   const matched = [];
   const sign = phrases[0].charAt(0);
   let newText = '';
@@ -990,6 +990,12 @@ function thisCommandOptions() {
   }
 }
 
+function showCommands() {
+  const commands = commandHandler.getCommands({ aliases: true, filtered: true });
+
+  domManipulator.addSubMenuItem('commands', createSubMenuItem(commands));
+}
+
 function populateMenu() {
   const menuItems = {
     runCommand: {
@@ -1000,7 +1006,7 @@ function populateMenu() {
     },
     commands: {
       itemName: 'CMDS',
-      func: commandHandler.getCommand('help').func,
+      func: showCommands,
       elementId: 'commands',
     },
     thisCommand: {

--- a/private/scripts/messenger.js
+++ b/private/scripts/messenger.js
@@ -145,7 +145,7 @@ function generateLink(text, className, func) {
 
   spanObj.addEventListener('click', (event) => {
     clickHandler.setClicked(true);
-    func(this);
+    func(event.target);
     domManipulator.focusInput();
     event.stopPropagation();
   });


### PR DESCRIPTION
- List of commands has been refactored and is once again working.
- Clicking on room/user names no longer crashes the frontend.
- The caret in the command input is moved to the end of the text when new text is appended
